### PR TITLE
github templateの導入

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: 既存バグについて
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Target view
+<!-- 対象画面 -->
+
+## Describe the bug
+<!-- バグ内容 -->
+
+## To Reproduce
+<!-- バグ再現手順:
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error -->
+
+## Expected behavior
+<!-- 期待値 -->
+
+## Screenshots
+<!-- スクショ等 -->
+
+## Additional context
+<!-- 備考 -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: 実装予定の機能について
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Description
+<!-- 内容 -->
+
+## Context
+<!-- どう対応するのか -->
+
+## Expected behavior
+<!-- 期待値 -->
+
+## Problem
+<!-- 問題や懸念点があれば記載 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Checklist before requesting a review
+- [ ] CIは通っているか
+- [ ] 依存するPRは存在しないか
+- [ ] issueのリンクが貼られていること
+
+## Related Issue
+<!-- ISSUEのリンク -->
+
+## Description
+<!-- このPRで行った対応について -->
+
+## Context
+<!-- 実装の詳細について -->
+
+## How Has This Been Tested?
+<!-- テスト方法について -->
+
+## Problem
+<!-- 問題や懸念点があれば記載 -->
+
+## Snapshots
+<!-- スクショ等 -->


### PR DESCRIPTION
## 概要
- #31 

## 内容
既に https://github.com/rei01saito/katask/pull/27 にて変更を行っていたため、以前のコミットを元に修正
対象コミット: [dockerとgithub周りを修正](https://github.com/rei01saito/katask/pull/27/commits/9e92e937a75e67739a0164c3b353301cfb1459cf)
